### PR TITLE
Add no-tab for ESLint 3.2.0+

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "indent": [2, "tab", {"VariableDeclarator": 1, "SwitchCase": 1}],
     "max-len": [2, 120, 2],
     "object-curly-spacing": [2, "never"],
-    "quotes": [2, "single", {"allowTemplateLiterals": true}]
+    "quotes": [2, "single", {"allowTemplateLiterals": true}],
+    "no-tabs": 0
   }
 }


### PR DESCRIPTION
As we're having TABS and no SPACES we need this rule for ESLint 3.2+

See http://eslint.org/docs/rules/no-tabs
